### PR TITLE
Implement is_planar()

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -84,6 +84,7 @@ t/83_bitmatrix.t
 t/84_all_cessors.t
 t/85_subgraph.t
 t/86_bipartite.t
+t/87_planar.t
 t/99_misc.t
 t/MyDGraph.pm
 t/MyGraph.pm

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -1856,9 +1856,7 @@ sub is_planar {
 
     my $path_graph = Graph->new(undirected => 1);
 
-    my $n = 0;
-    my $d = 0;
-    my %order;
+    my ($n, $d, %order) = (0, 0);
     my $operations = {
         pre => sub {
             $order{$_[0]} = $n;

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -1852,10 +1852,7 @@ sub is_planar {
     &expect_undirected;
     my ($g) = @_;
 
-    my @paths_at;
-    for ($g->vertices) {
-        push @paths_at, [];
-    }
+    my @paths_at = map [], 1..$g->vertices;
 
     my $path_graph = Graph->new(undirected => 1);
 

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -1851,11 +1851,8 @@ sub is_bipartite {
 sub is_planar {
     &expect_undirected;
     my ($g) = @_;
-
     my @paths_at = map [], 1..$g->vertices;
-
     my $path_graph = Graph->new(undirected => 1);
-
     my ($n, $d, %order) = (0, 0);
     my $operations = {
         pre => sub {
@@ -1873,7 +1870,6 @@ sub is_planar {
             $d++;
         },
     };
-
     require Graph::Traversal::DFS;
     Graph::Traversal::DFS->new( $g, %$operations )->dfs;
     return $path_graph->is_bipartite;

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -1827,8 +1827,7 @@ sub directed_copy {
 
 sub is_bipartite {
     &expect_undirected;
-    my $g = $_[0];
-
+    my ($g) = @_;
     my $is_bipartite = 1;
     my %colors;
     my $operations = {
@@ -1842,7 +1841,6 @@ sub is_bipartite {
             $is_bipartite = '' if $colors{$_[0]} == $colors{$_[1]};
         },
     };
-
     require Graph::Traversal::DFS;
     Graph::Traversal::DFS->new( $g, %$operations )->dfs;
     return $is_bipartite;

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -1850,7 +1850,7 @@ sub is_bipartite {
 
 sub is_planar {
     &expect_undirected;
-    my $g = $_[0];
+    my ($g) = @_;
 
     my @paths_at;
     for ($g->vertices) {

--- a/lib/Graph.pod
+++ b/lib/Graph.pod
@@ -564,6 +564,10 @@ Return true if the graph is acyclic (does not contain any cycles).
 Return true if the graph is bipartite (also known as 2-colourable, or
 not containing cycles of odd length). Currently only works with undirected graphs.
 
+=item is_planar
+
+Return true if the graph is planar. Currently only works with undirected graphs.
+
 =back
 
 To find a cycle, use L</find_a_cycle>.

--- a/lib/Graph.pod
+++ b/lib/Graph.pod
@@ -1,5 +1,7 @@
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Graph - graph data structures and algorithms
@@ -566,7 +568,10 @@ not containing cycles of odd length). Currently only works with undirected graph
 
 =item is_planar
 
-Return true if the graph is planar. Currently only works with undirected graphs.
+Return true if the graph is planar. The implementation is based on left-right
+planarity test as described in
+L<A characterization of planar graphs by Trémaux orders, de Fraysseix and Rosenstiehl|https://doi.org/10.1007/BF02579375>.
+Currently only works with undirected graphs.
 
 =back
 

--- a/t/87_planar.t
+++ b/t/87_planar.t
@@ -35,4 +35,21 @@ $g5->add_cycle('A'..'D');
 $g5->add_cycle('1'..'6');
 ok($g5->is_planar);
 
+my $g6 = Graph::Undirected->new; # K5
+for my $A ('A'..'E') {
+    for my $B ('A'..'E') {
+        next if $A eq $B;
+        $g6->add_edge( $A, $B );
+    }
+}
+ok(!$g6->is_planar);
+
+my $g7 = Graph::Undirected->new; # K3,3
+for my $A ('A'..'C') {
+    for my $B ('1'..'3') {
+        $g7->add_edge( $A, $B );
+    }
+}
+ok(!$g7->is_planar);
+
 done_testing;

--- a/t/87_planar.t
+++ b/t/87_planar.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use Graph::Undirected;
+
+use Test::More;
+
+my $g0 = Graph::Undirected->new;
+$g0->add_path('A'..'Z');
+ok($g0->is_planar);
+
+my $g1 = Graph::Undirected->new;
+$g1->add_cycle('A'..'C');
+ok($g1->is_planar);
+
+my $g2 = Graph::Undirected->new;
+$g2->add_cycle('A'..'D');
+ok($g2->is_planar);
+
+my $g3 = Graph::Undirected->new;
+for my $A ('A'..'Z') {
+    for my $B ('1'..'9') {
+        $g3->add_edge($A, $B);
+    }
+}
+ok(!$g3->is_planar);
+
+my $g4 = Graph::Undirected->new;
+$g4->add_cycle('A'..'C');
+$g4->add_cycle('1'..'6');
+ok($g4->is_planar);
+
+my $g5 = Graph::Undirected->new;
+$g5->add_cycle('A'..'D');
+$g5->add_cycle('1'..'6');
+ok($g5->is_planar);
+
+done_testing;


### PR DESCRIPTION
This PR implements graph planarity check in `is_planar()` for undirected graphs. The implementation is based on [left-right planarity test](https://en.wikipedia.org/w/index.php?title=Left-right_planarity_test&oldid=1158148963), whose accessable full-text (at least to me) origin seems to be [de Fraysseix and Rosenstiehl (1985)](https://doi.org/10.1007%2FBF02579375).

I have not included the mention of left-right planarity test in the code as I was unsure where it belongs. Should it be visible in the POD, or only in the code, as implementation detail?