### PR TITLE
Implement `connected_subgraphs()`

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -86,6 +86,7 @@ t/85_subgraph.t
 t/86_bipartite.t
 t/87_planar.t
 t/88_max_cliq.t
+t/89_connected_subgraphs.t
 t/99_misc.t
 t/MyDGraph.pm
 t/MyGraph.pm

--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -2901,4 +2901,23 @@ sub betweenness {
     return %Cb;
 }
 
+sub connected_subgraphs {
+    my $g = shift;
+    require Set::Object;
+    my @subgraphs = ( [ map { Set::Object->new($_) } $g->vertices ] );
+    for (2..scalar $g->vertices) {
+        my %seen;
+        for my $subgraph (@{$subgraphs[-1]}) {
+            for my $neighbour ((Set::Object->new( map { $g->neighbours($_) } $subgraph->members ) - $subgraph)->members) {
+                my $new_subgraph = Set::Object->new($subgraph->members, $neighbour);
+                my $key = join '|', @$new_subgraph;
+                next if exists $seen{$key};
+                $seen{$key} = $new_subgraph;
+            }
+        }
+        push @subgraphs, [values %seen];
+    }
+    return map { $g->subgraph([$_->members]) } map { @$_ } @subgraphs;
+}
+
 1;

--- a/lib/Graph.pod
+++ b/lib/Graph.pod
@@ -2784,6 +2784,12 @@ coefficients.
 Returns an empty list (and therefore undefined in scalar context) if
 the graph has no vertices.
 
+=item connected_subgraphs
+
+    @s = $g->connected_subgraphs;
+
+Returns all connected subgraphs of $g.
+
 =item subgraph_by_radius
 
     $s = $g->subgraph_by_radius(@v, $radius);

--- a/t/89_connected_subgraphs.t
+++ b/t/89_connected_subgraphs.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+
+use Graph::Undirected;
+
+use Test::More;
+
+my $g;
+my @subgraphs;
+
+# Caffeine molecule, heavy atoms only
+$g = Graph::Undirected->new;
+$g->add_path('A'..'K');
+$g->add_edge('C', 'L');
+$g->add_edge('E', 'M');
+$g->add_edge('I', 'N');
+$g->add_edge('B', 'J');
+$g->add_edge('D', 'H');
+
+@subgraphs = $g->connected_subgraphs;
+is(@subgraphs, 1153);
+
+my @by_size;
+for (@subgraphs) {
+    $by_size[scalar $_->vertices]++;
+}
+
+my @result0 = qw( 0 14 15 23 40 68 112 165 206 208 162 93 37 9 1 );
+
+for (1..$#result0) {
+    is($by_size[$_], $result0[$_]);
+}
+
+# K5
+$g = Graph::Undirected->new;
+for my $i (1..5) {
+    for my $j ($i+1..5) {
+        $g->add_edge($i, $j);
+    }
+}
+
+@subgraphs = $g->connected_subgraphs;
+is(@subgraphs, 31);
+
+# Line of 5 vertices
+$g = Graph::Undirected->new;
+$g->add_path(1..5);
+
+@subgraphs = $g->connected_subgraphs;
+is(@subgraphs, 15);
+
+done_testing;


### PR DESCRIPTION
This PR introduces `connected_subgraphs()` which generates all the connected subgraphs of a given graph. I needed this for my applications, and I was unable to find anything similar even in Python's NetworkX.

Apparently, there does not seem to be a trivial algorithm for that. Intuitive solution of checking each of 2^N vertex subsets for connectivity is quite expensive and inefficient for sparse graphs.

My implementation is based on a modified BFS starting at each vertex and forking off on every neighbour. Intuitively (= no proof) this should work on directed and multiedge graphs, as `neighbours()` is used in this modified BFS.

Current implementation could be made more efficient by using something else than the difference of `Set::Object` objects to find the next expansion tier for the modified BFS. Maybe a matrix form. But for small graphs this does the trick.